### PR TITLE
Sp restore script dev

### DIFF
--- a/sp_restorescript.sql
+++ b/sp_restorescript.sql
@@ -393,6 +393,15 @@ BEGIN
 	--if WithMove parameters are set, create WITH MOVE statements
 	IF (@WithMoveDataPath IS NOT NULL) AND (@WithMoveLogPath IS NOT NULL) 
 	BEGIN
+
+		--append \ to the end of path if it's not already
+
+		IF (SELECT SUBSTRING(@WithMoveDataPath,LEN(@WithMoveDataPath), 1)) != '\'
+			SET @WithMoveDataPath =  @WithMoveDataPath + '\'
+
+		IF (SELECT SUBSTRING(@WithMoveLogPath,LEN(@WithMoveLogPath), 1)) != '\'
+			SET @WithMoveLogPath =  @WithMoveLogPath + '\'
+
 		--generate MOVE statement
 		DECLARE @WithMoveCmd VARCHAR(3000)
 

--- a/sp_restorescript.sql
+++ b/sp_restorescript.sql
@@ -62,6 +62,7 @@ Backup type added to the output
 29 August 2019
 @Credential parameter added
 
+
 MIT License
 ------------
 
@@ -143,7 +144,8 @@ CREATE PROC sp_RestoreScript
 @StandBy VARCHAR(260) = NULL,
 @RestoreTimeEstimate BIT = 0,
 @Credential VARCHAR(128) = NULL,
-@IncludeCopyOnly BIT = 1
+@IncludeCopyOnly BIT = 1,
+@SingleUser BIT = 0
 )
 
 AS
@@ -348,6 +350,14 @@ FETCH NEXT FROM DatabaseCur INTO @DatabaseName, @RestoreAsName
 
 WHILE @@FETCH_STATUS = 0 
 BEGIN
+
+	--Insert single user command
+	IF @SingleUser = 1
+	BEGIN
+		INSERT INTO #BackupCommands (DBName, command)
+		VALUES (@DatabaseName, 'ALTER DATABASE ' + COALESCE(QUOTENAME(@RestoreAsName), QUOTENAME(@DatabaseName)) + ' SET SINGLE_USER WITH ROLLBACK IMMEDIATE')
+	END
+
 
 	--Get last full backup for required timeframe
 	IF (@RestoreOptions IN ('PointInTime','ToLog','ToDiff','ToFull','DiffOnly'))

--- a/sp_restorescript.sql
+++ b/sp_restorescript.sql
@@ -35,7 +35,7 @@
                   @`                                                                                                    
                   #                                                                                                     
                                                                                                                             
-sp_RestoreScript 1.7 BETA                                                                                                             
+sp_RestoreScript 1.7                                                                                                             
 Written By David Fowler
 29 June 2017
 Generate a set of backup commands to restore a database(s) to a specified time         
@@ -62,9 +62,9 @@ Backup type added to the output
 29 August 2019
 @Credential parameter added
 
-23 September 2020
-@IncludeCopyOnly parameter added
-@SingleUser parameter added
+29 September 2020
+@IncludeCopyOnly parameter added 
+@SingleUser parameter added 
 File names changed to match db names when WITH MOVE is used
 Fix to prevent log backups that were too early from being selected
 Fix to add \ at the end of file paths if not already there

--- a/sp_restorescript.sql
+++ b/sp_restorescript.sql
@@ -142,7 +142,8 @@ CREATE PROC sp_RestoreScript
 @BrokerOptions VARCHAR(30) = '',
 @StandBy VARCHAR(260) = NULL,
 @RestoreTimeEstimate BIT = 0,
-@Credential VARCHAR(128) = NULL
+@Credential VARCHAR(128) = NULL,
+@IncludeCopyOnly BIT = 1
 )
 
 AS
@@ -358,7 +359,8 @@ BEGIN
 			INNER JOIN msdb.dbo.backupmediafamily mediafamily ON backupset.media_set_id = mediafamily.media_set_id
 			WHERE backupset.database_name = @DatabaseName
 			AND backupset.backup_start_date < @RestoreToDate
-			AND backupset.type = 'D')
+			AND backupset.type = 'D'
+            AND is_copy_only IN (0,@IncludeCopyOnly))
 
 		INSERT INTO #BackupCommands
 		SELECT DISTINCT  backup_start_date, @DatabaseName AS DBName,
@@ -416,7 +418,8 @@ BEGIN
 			INNER JOIN msdb.dbo.backupmediafamily mediafamily ON backupset.media_set_id = mediafamily.media_set_id
 			WHERE backupset.database_name = @DatabaseName
 			AND backupset.backup_start_date < @RestoreToDate
-			AND backupset.type = 'I')
+			AND backupset.type = 'I'
+            AND is_copy_only IN (0,@IncludeCopyOnly))
 
 		INSERT INTO #BackupCommands
 		SELECT DISTINCT  backup_start_date, @DatabaseName AS DBName,
@@ -440,7 +443,8 @@ BEGIN
 			AND backupset.backup_start_date >
 				(SELECT COALESCE(MAX(backup_start_date),@FirstLogToRestore) FROM #BackupCommands)
 			AND backupset.backup_start_date < @RestoreToDate
-			AND backupset.type = 'L')
+			AND backupset.type = 'L'
+            AND is_copy_only IN (0,@IncludeCopyOnly))
 
 		INSERT INTO #BackupCommands
 		SELECT DISTINCT  backup_start_date, @DatabaseName AS DBName,
@@ -463,7 +467,8 @@ BEGIN
 			INNER JOIN msdb.dbo.backupmediafamily mediafamily ON backupset.media_set_id = mediafamily.media_set_id
 			WHERE backupset.database_name = @DatabaseName
 			AND backupset.backup_start_date > @RestoreToDate
-			AND backupset.type = 'L')
+			AND backupset.type = 'L'
+            AND is_copy_only IN (0,@IncludeCopyOnly))
 
 		INSERT INTO #BackupCommands
 		SELECT DISTINCT  backup_start_date, @DatabaseName AS DBName,

--- a/sp_restorescript.sql
+++ b/sp_restorescript.sql
@@ -388,7 +388,12 @@ BEGIN
 
 		SET @WithMoveCmd = ','
 
-		SELECT @WithMoveCmd = @WithMoveCmd + STUFF((SELECT ',' + ' MOVE ''' + name + ''' TO ''' + REPLACE(physical_name,REVERSE(SUBSTRING(REVERSE(physical_name),CHARINDEX('\',REVERSE(physical_name),0), LEN(physical_name))),@WithMoveDataPath) + ''''
+		SELECT @WithMoveCmd = @WithMoveCmd + STUFF((SELECT ',' + ' MOVE ''' + name + ''' TO ''' + 
+		CASE 
+			WHEN @RestoreAsName IS NULL THEN REPLACE(physical_name,REVERSE(SUBSTRING(REVERSE(physical_name),CHARINDEX('\',REVERSE(physical_name),0), LEN(physical_name))),@WithMoveDataPath) + ''''
+			ELSE REPLACE(LEFT(physical_name,(LEN(physical_name)-CHARINDEX('\',REVERSE(physical_name),0)+1)),LEFT(physical_name,(LEN(physical_name)-CHARINDEX('\',REVERSE(physical_name),0)+1)),@WithMoveDataPath) /* Base Path */ 
+				+REPLACE(RIGHT(physical_name,(CHARINDEX('\',REVERSE(physical_name))-1)),@DatabaseName,@RestoreAsName) + '''' /* append new filename and extension */
+		END
 		FROM sys.master_files
 		WHERE database_id = DB_ID(@DatabaseName)
 		AND type_desc = 'ROWS'
@@ -396,7 +401,12 @@ BEGIN
 
 		SET @WithMoveCmd = @WithMoveCmd + ','
 
-		SELECT @WithMoveCmd = @WithMoveCmd + STUFF((SELECT ',' +  'MOVE ''' + name + ''' TO ''' + REPLACE(physical_name,REVERSE(SUBSTRING(REVERSE(physical_name),CHARINDEX('\',REVERSE(physical_name),0), LEN(physical_name))),@WithMoveLogPath) + ''''
+		SELECT @WithMoveCmd = @WithMoveCmd + STUFF((SELECT ',' +  'MOVE ''' + name + ''' TO ''' +
+		CASE 
+			WHEN @RestoreAsName IS NULL THEN REPLACE(physical_name,REVERSE(SUBSTRING(REVERSE(physical_name),CHARINDEX('\',REVERSE(physical_name),0), LEN(physical_name))),@WithMoveLogPath) + ''''
+			ELSE REPLACE(LEFT(physical_name,(LEN(physical_name)-CHARINDEX('\',REVERSE(physical_name),0)+1)),LEFT(physical_name,(LEN(physical_name)-CHARINDEX('\',REVERSE(physical_name),0)+1)),@WithMoveLogPath) /* Base Path */ 
+				+REPLACE(RIGHT(physical_name,(CHARINDEX('\',REVERSE(physical_name))-1)),@DatabaseName,@RestoreAsName) + '''' /* append new filename and extension */
+		END
 		FROM sys.master_files
 		WHERE database_id = DB_ID(@DatabaseName)
 		AND type_desc = 'LOG'


### PR DESCRIPTION
sp_restorescript 1.7 release

@IncludeCopyOnly parameter added 
@SingleUser parameter added 
File names changed to match db names when WITH MOVE is used
Fix to prevent log backups that were too early from being selected
Fix to add \ at the end of file paths if not already there
Support for DISK, TAPE, LOGICAL DEVICES and Azure blob store backups added
Support for STOPATMARK and STOPBEFOREMARK added